### PR TITLE
Using Tokens Improvements

### DIFF
--- a/GazelleUI.py
+++ b/GazelleUI.py
@@ -119,7 +119,7 @@ def settings_path():
 @login_required
 def snatches():
   torrents = torrent.get_all()
-  return render_template('snatches.html', torrents=torrents, userinfo=database.userinfo())
+  return render_template('snatches.html', torrents=torrents, userinfo=database.userinfo(), settings=settings.get_all())
 
 @app.route('/delete_sub/<int:sub_id>')
 @login_required
@@ -137,7 +137,7 @@ def create_sub():
 @login_required
 def subscriptions():
   subs = database.subscriptions()
-  return render_template('subscriptions.html', subs=subs, userinfo=database.userinfo())
+  return render_template('subscriptions.html', subs=subs, userinfo=database.userinfo(), settings=settings.get_all())
 
 # Serve Static Assets
 @app.route('/assets/<path:filename>')

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -37,7 +37,7 @@
       <p>
       {% if userinfo is defined %}
         {{ userinfo[0] }} / Up: {{ userinfo[1] }} / Down: {{ userinfo[2] }} / Ratio: {{ userinfo[3] }} / Required: {{ userinfo[4] }} /
-        {% if settings is defined and settings.use_tokens is defined and settings.use_tokens[2] %}
+        {% if settings is defined and settings.use_tokens is defined and settings.use_tokens[1] == "true" %}
           Tokens: {{ settings.use_tokens[2]|int }} /
         {% endif %}
       {% endif %}

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -79,7 +79,7 @@
     </form>
 
     <h4>Tokens</h4>
-    <p>Use freelech tokens when available, you currently have {{ settings.use_tokens[2]|int }}</p>
+    <p>Use freeleech tokens when available, you currently have {{ settings.use_tokens[2]|int }}.</p>
     <form action="/settings" method="post" id="tokens-form">
       <input type="hidden" value="use_tokens" name="setting">
       <input type="hidden" id="use-tokens-hidden" name="value_1" value="{% if settings.use_tokens[1] == 'true' %}true{% else %}false{% endif %}">


### PR DESCRIPTION
This improves the following.

- Fixes a misspelling of "freelech" to "freeleech".
- Passes settings to snatches and subscriptions pages so that available tokens shows.
- Tweaks the footer so that available tokens only shows if the token setting is enabled. I'm unsure if this is the intended behavior. If it isn't, this can be removed.

This will fix my issue #41.