### PR TITLE
Convert mappings into an enum

### DIFF
--- a/GazelleUI.py
+++ b/GazelleUI.py
@@ -90,7 +90,7 @@ def index():
 def artist():
   query = request.args['q']
   results = wat.get_artist(query)
-  return render_template('artist.html', results=results, userinfo=database.userinfo(), settings=settings.get_all())
+  return render_template('artist.html', results=results, userinfo=database.userinfo(), settings=settings.get_all(), mappings=autofetch.mappings)
 
 
 @app.route("/want", methods=['POST'])
@@ -137,7 +137,7 @@ def create_sub():
 @login_required
 def subscriptions():
   subs = database.subscriptions()
-  return render_template('subscriptions.html', subs=subs, userinfo=database.userinfo())
+  return render_template('subscriptions.html', subs=subs, userinfo=database.userinfo(), mappings=autofetch.mappings)
 
 # Serve Static Assets
 @app.route('/assets/<path:filename>')

--- a/lib/autofetch.py
+++ b/lib/autofetch.py
@@ -1,27 +1,29 @@
 from . import database
 from . import torrent
 from . import wat
+from enum import Enum
 
-def word_to_type(release_type):
-  mapping = {
-    'Album': 1,
-    'Soundtrack': 3,
-    'EP': 5,
-    'Anthology': 6,
-    'Compilation': 7,
-    'Single': 9,
-    'Live album': 11,
-    'Remix': 13,
-    'Bootleg': 14,
-    'Interview': 15,
-    'Mixtape': 16,
-    'Demo': 17,
-    'Concert Recording': 18,
-    'DJ Mix': 19,
-    'Unknown': 21
-  }
-
-  return mapping[release_type]
+# https://www.notinventedhere.org/articles/python/how-to-use-strings-as-name-aliases-in-python-enums.html
+mappings = Enum(
+    value='mappings',
+    names=[
+        ('Album', 1),
+        ('Soundtrack', 3),
+        ('EP', 5),
+        ('Anthology', 6),
+        ('Compilation', 7),
+        ('Single', 9),
+        ('Live album', 11),
+        ('Remix', 13),
+        ('Bootleg', 14),
+        ('Interview', 15),
+        ('Mixtape', 16),
+        ('Demo', 17),
+        ('Concert Recording', 18),
+        ('DJ Mix', 19),
+        ('Unknown', 21)
+    ]
+)
 
 def create_subscription(data):
   query = 'insert into subscriptions(search_type, term, quality, release_type) values (' + \

--- a/templates/artist.html
+++ b/templates/artist.html
@@ -18,21 +18,9 @@
 
   <select class="u-full-width js-type-filter">
     <option value="0">All Releases</option>
-    <option value="1" selected>Albums</a>
-    <option value="3">Soundtracks</option>
-    <option value="5">EPs</option>
-    <option value="6">Anthologies</option>
-    <option value="7">Compilations</option>
-    <option value="9">Singles</option>
-    <option value="11">Live albums</option>
-    <option value="13">Remixs</option>
-    <option value="14">Bootlegs</option>
-    <option value="15">Interviews</option>
-    <option value="16">Mixtape</option>
-    <option value="17">Demo</option>
-    <option value="18">Concert Recording</option>
-    <option value="19">DJ Mix</option>
-    <option value="21">Unknown</option>
+    {% for mapping in mappings %}
+        <option value="{{mapping.value}}" {% if mapping.value == 1 %}selected{% endif %}>{{mapping.name}}</option>
+    {% endfor %}
   </select>
 
   <input type="search" class="u-full-width js-text-filter" placeholder="Filter by title">

--- a/templates/subscriptions.html
+++ b/templates/subscriptions.html
@@ -16,21 +16,9 @@
   </select>
 
   <select name="release_type">
-    <option value="1">Albums</option>
-    <option value="3">Soundtracks</option>
-    <option value="5">EPs</option>
-    <option value="6">Anthologies</option>
-    <option value="7">Compilations</option>
-    <option value="9">Singles</option>
-    <option value="11">Live albums</option>
-    <option value="13">Remixs</option>
-    <option value="14">Bootlegs</option>
-    <option value="15">Interviews</option>
-    <option value="16">Mixtape</option>
-    <option value="17">Demo</option>
-    <option value="18">Concert Recording</option>
-    <option value="19">DJ Mix</option>
-    <option value="21">Unknown</option>
+    {% for mapping in mappings %}
+        <option value="{{mapping.value}}">{{mapping.name}}</option>
+    {% endfor %}
   </select>
 
   <input type="submit" class="button" value="Add Subscription">
@@ -52,10 +40,10 @@
   <tbody>
     {% for sub in subs %}
       <tr>
-        <td>{{ sub['search_type'] }}</td>
+        <td>{{ sub['search_type']|capitalize }}</td>
         <td>{{ sub['term'] }}</td>
         <td>{{ sub['quality'] }}</td>
-        <td>{{ sub['release_type'] }}</td>
+        <td>{{ mappings(sub['release_type']|int).name }}</td>
         <td><a href="/delete_sub/{{ sub['id'] }}">Delete</a></td>
       </tr>
     {% endfor %}


### PR DESCRIPTION
This improves the following.

- Replaces the unused "word_to_type" function with a centralized mapping enum.
- The main GazelleUI.py now passes the above mappings to the artist and subscriptions pages.
- Removed the mappings in the artist and subscriptions pages, now loads from the enum passed into it. No visible changes.
- "artist" type is now capitalized in the subscriptions page.
- "Release Type" in the subscriptions table now shows the name rather than just the number.

This will fix my issue #38.