### PR TITLE
Add 24bit Lossless + Rearrange

### DIFF
--- a/templates/subscriptions.html
+++ b/templates/subscriptions.html
@@ -10,9 +10,10 @@
   <input name="term" type="search" placeholder="search term">
 
   <select name="quality">
-    <option value="V0 (VBR)">V0 (VBR)</option>
+    <option value="24bit Lossless">24bit Lossless</option>
+    <option value="Lossless" selected>Lossless</option>
     <option value="320">320</option>
-    <option value="Lossless">Lossless</option>
+    <option value="V0 (VBR)">V0 (VBR)</option>
   </select>
 
   <select name="release_type">


### PR DESCRIPTION
This improves the following.

- Adds 24bit Lossless to the quality select dropdown.
- Reorganized the dropdown to auto-select Lossless, with descending quality.

This will partially fix my issue #44.