### PR TITLE
Add "Release Media" to Subscriptions

### DIFF
--- a/lib/autofetch.py
+++ b/lib/autofetch.py
@@ -26,11 +26,12 @@ mappings = Enum(
 )
 
 def create_subscription(data):
-  query = 'insert into subscriptions(search_type, term, quality, release_type) values (' + \
+  query = 'insert into subscriptions(search_type, term, quality, release_type, release_media) values (' + \
           '"' + data['search_type'] + '", ' + \
           '"' + data['term'] + '", ' + \
           '"' + data['quality'] + '", ' + \
-          '"' + data['release_type'] + '")'
+          '"' + data['release_type'] + '", ' + \
+          '"' + data['release_media'] + '")'
 
   database.update(query)
 
@@ -42,8 +43,9 @@ def enqueue(data):
     print("Skipping, already downloaded")
 
 def fetch_new_torrents(sub):
-  print(sub['search_type'] + ' search for "' + sub['term'] + \
-    '" with quality ' + sub['quality'] + ' and release type ' + str(sub['release_type']))
+  print(sub['search_type'].title() + ' search for "' + sub['term'] + \
+    '" with quality ' + sub['quality'] + ', release type ' + str(mappings(int(sub['release_type'])).name) + \
+    ', and release media ' + str(sub['release_media']))
 
   if sub['search_type'] == 'artist':
     data = wat.get_artist(sub['term'])
@@ -55,7 +57,7 @@ def fetch_new_torrents(sub):
     for group in data['torrentgroup']:
       if int(group['releaseType']) == int(sub['release_type']):
         for t in group['torrent']:
-          if t['encoding'] == sub['quality']:
+          if sub['quality'] in (t['encoding'], None) and sub['release_media'] in (t['media'], None):
             print("Found " + group['groupName'] + ' (' + str(t['id']) + ')')
             t.update({
               'artist': data['name'],

--- a/lib/database.py
+++ b/lib/database.py
@@ -36,7 +36,8 @@ SCHEMA = {
       'search_type',
       'term',
       'quality',
-      'release_type'
+      'release_type',
+      'release_media'
     ]
 }
 
@@ -57,6 +58,12 @@ def init():
 
   for k in list(SCHEMA.keys()):
     con.cursor().execute("create table if not exists " + k + "(" + ", ".join(SCHEMA[k]) + ");")
+
+    for c in SCHEMA[k]:
+        try:
+            con.cursor().execute("alter table " + k + " add column " + c.split()[0] + ";")
+        except:
+            continue
 
   for setting in DEFAULT_SETTINGS:
     con.cursor().execute("insert into settings(key, value_1, value_2) select '" + "', '".join(setting) + "' where not exists(select 1 from settings where key = '" + setting[0] + "')")
@@ -87,7 +94,7 @@ def userinfo():
   return fetch('select * from user')[0]
 
 def subscriptions():
-  res = fetch('select search_type, term, quality, release_type, id from subscriptions')
+  res = fetch('select search_type, term, quality, release_type, id, release_media from subscriptions')
   h = []
   for r in res:
     h.append({
@@ -95,7 +102,8 @@ def subscriptions():
       'term': r[1],
       'quality': r[2],
       'release_type': r[3],
-      'id': r[4]
+      'id': r[4],
+      'release_media': r[5]
       })
 
   return h

--- a/templates/subscriptions.html
+++ b/templates/subscriptions.html
@@ -21,6 +21,18 @@
         <option value="{{mapping.value}}">{{mapping.name}}</option>
     {% endfor %}
   </select>
+  
+  <select name="release_media">
+    <option value="CD" selected>CD</option>
+    <option value="DVD">DVD</option>
+    <option value="Vinyl">Vinyl</option>
+    <option value="Soundboard">Soundboard</option>
+    <option value="SACD">SACD</option>
+    <option value="DAT">DAT</option>
+    <option value="Cassette">Cassette</option>
+    <option value="WEB">WEB</option>
+    <option value="Blu-Ray">Blu-Ray</option>
+  </select>
 
   <input type="submit" class="button" value="Add Subscription">
 </form>
@@ -35,6 +47,7 @@
       <th>Term</th>
       <th>Quality</th>
       <th>Release Type</th>
+      <th>Release Media</th>
       <th></th>
     </tr>
   </thead>
@@ -45,6 +58,7 @@
         <td>{{ sub['term'] }}</td>
         <td>{{ sub['quality'] }}</td>
         <td>{{ mappings(sub['release_type']|int).name }}</td>
+        <td>{{ sub['release_media'] }}</td>
         <td><a href="/delete_sub/{{ sub['id'] }}">Delete</a></td>
       </tr>
     {% endfor %}


### PR DESCRIPTION
This improves the following.

- Adds "Release Media" as a subscription setting, letting the user choose what release media they want.
- Tweaked the database to add missing columns if they don't exist in the schema. Please review this carefully.
- Prettied the log output when searching for torrents a little.

Backwards compatibility *should* be maintained by ignoring the release media setting if one is not set. For future purposes (i.e. adding an "All" option to quality and/or media settings, which could be set to an empty value in the database), the same is true for the quality setting, despite it not being presently used.

Though I didn't change it myself, the `break` on line 67 could be changed to a `continue` with this PR, to download all releases. I have not done so to prevent current instances downloading a bunch of new torrents suddenly. It could be a future setting, as in either "First" or "All".

This will fix my issue #44.